### PR TITLE
Return the email references for an S3 event in a callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,3 @@ Enables super admins to send email to groups in a Rabble Rouser instance.
 #### Initial
 
 To create/modify the AWS resources involved with this lambda, run `deploy.sh`, which uses terraform. This repo is a little different from most of the others, because it contains its own terraform code, rather than having it in the `infra` repo. It's just a little something we're trying out.
-
-#### Updating the lambda code
-
-The CI pipeline will package the code into a .zip file and upload it to S3, but getting the lambda to pick up the changes is a different matter. Right now, the way to do that is with a manual command. We're looking at automating it.
-
-    aws lambda update-function-code --function-name=group-mail-receiver --s3-bucket=[S3 BUCKET NAME] --s3-key=[FILE PATH WITHIN S3 BUCKET]

--- a/lambda/bin/lambda-deploy.sh
+++ b/lambda/bin/lambda-deploy.sh
@@ -12,3 +12,4 @@ zip -r $PACKAGE_NAME.zip index.js src node_modules/ -x __tests__
 
 echo 'UPLOADING TO S3'
 aws s3 cp $PACKAGE_NAME.zip s3://rabblerouser-ses-artefacts/lambdas/$PACKAGE_NAME.zip
+aws lambda update-function-code --function-name=group-mail-receiver --s3-bucket=rabblerouser-ses-artefacts --s3-key=lambdas/group-mail-receiver.zip

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
 const handler = require('./src');
-const aws = require('aws-sdk');
-const s3 = new aws.S3({ apiVersion: '2006-03-01' });
 
 exports.handler = handler;

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const request = require('request-promise');
 const handler = require('./src');
+const aws = require('aws-sdk');
+const s3 = new aws.S3({ apiVersion: '2006-03-01' });
 
-// const endpoint = process.env.LISTENER_ENDPOINT;
-// const authToken = process.env.LISTENER_AUTH_TOKEN;
-exports.handler = handler(request);
+exports.handler = handler;

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -2,4 +2,6 @@
 
 const handler = require('./src');
 
+// const groupMailerEndpoint = process.env.FORWARD_TO_ENDPOINT;
+
 exports.handler = handler;

--- a/lambda/src/__tests__/index-test.js
+++ b/lambda/src/__tests__/index-test.js
@@ -11,23 +11,20 @@ describe('group-mail-receiver lambda function', () => {
 
     it('returns the bucket name, key, and all records for the event', () => {
       const bucketName = "name of the bucket";
-      const object_key = "key_of_the_file";
-      const s3_info = {
-          "bucket": {"name": bucketName},
-          "object": { "key": object_key }
-      };
-      const records = [{ "s3": s3_info }]
-      const event = {"Records": records};
+      const objectKey1 = "key of the first file";
+      const objectKey2 = "key of the second file";
+      const s3Info1 = { "bucket": { "name": bucketName }, "object": { "key": objectKey1 } };
+      const s3Info2 = { "bucket": { "name": bucketName }, "object": { "key": objectKey2 } };
+      const event = { "Records": [{ "s3": s3Info1 }, { "s3": s3Info2 }] };
 
-      let expected_info = {
-        bucket: bucketName,
-        key: object_key,
-        records: records,
-      };
+      const expectedEmailReferences = [
+        { bucket: bucketName, key: objectKey1 },
+        { bucket: bucketName, key: objectKey2 },
+      ];
 
       handler(event, null, callback);
 
-      expect(callback).to.have.been.calledWith(null, expected_info);
+      expect(callback).to.have.been.calledWith(null, expectedEmailReferences);
     });
   });
 });

--- a/lambda/src/index.js
+++ b/lambda/src/index.js
@@ -4,7 +4,7 @@ module.exports = (event, context, callback) => {
   const emailReferences = event.Records.map(record => {
     return {
       bucket: record.s3.bucket.name,
-      key: decodeURIComponent(record.s3.object.key.replace(/\+/g, ' ')),
+      key: record.s3.object.key,
     };
   });
   callback(null, emailReferences);

--- a/lambda/src/index.js
+++ b/lambda/src/index.js
@@ -1,46 +1,12 @@
 'use strict';
 
-const getEmailFromS3 = (s3, emailRecord) => {
-    return new Promise((resolve, reject) => {
-        s3.getObject(emailRecord, (err, data) => {
-            if(err) {
-                reject(err);
-            } else {
-                console.log("EMAIL CONTENTS:", data);
-                resolve(data);
-            }
-        }); 
-    });
-}
-
-const createPost = (emailRecord, uri, secret) => {
-  return {
-      method: 'POST',
-      uri,
-      body: emailRecord.Body,
-      json: true,
-      headers: { Authorization: secret }
-  };
-}
-
-module.exports = (s3, request, uri, secret) => (event, context, callback) => {
-    const emailEvents = event.Records.map(record => {
-        return {
-            Bucket: record.s3.bucket.name,
-            Key: record.s3.object.key
-        };
-    });
-
-    const requestAttempts = emailEvents.map(emailRecord => 
-        getEmailFromS3(s3, emailRecord)
-        .then(emailRecord => createPost(emailRecord, uri, secret))
-        .then(postData => request(postData)))
-
-    return Promise.all(requestAttempts)
-        .then(() => {
-            callback(null, 'ok');
-        }).catch(err => {
-            console.log("BARF", err);
-            callback(err);
-        });
+module.exports = (event, context, callback) => {
+  const bucket = event.Records[0].s3.bucket.name;
+  const key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
+  const info = {
+    bucket,
+    key,
+    records: event.Records,
+  }
+  callback(null, info);
 };

--- a/lambda/src/index.js
+++ b/lambda/src/index.js
@@ -1,12 +1,11 @@
 'use strict';
 
 module.exports = (event, context, callback) => {
-  const bucket = event.Records[0].s3.bucket.name;
-  const key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
-  const info = {
-    bucket,
-    key,
-    records: event.Records,
-  }
-  callback(null, info);
+  const emailReferences = event.Records.map(record => {
+    return {
+      bucket: record.s3.bucket.name,
+      key: decodeURIComponent(record.s3.object.key.replace(/\+/g, ' ')),
+    };
+  });
+  callback(null, emailReferences);
 };

--- a/terraform/group_mail_receiver.tf
+++ b/terraform/group_mail_receiver.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "group_mail_receiver" {
 
   environment = {
     variables = {
-      LISTENER_ENDPOINT = "blah"
+      LISTENER_ENDPOINT = "${var.forward_to}"
     }
   }
 }

--- a/terraform/group_mail_receiver.tf
+++ b/terraform/group_mail_receiver.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "group_mail_receiver" {
 
   environment = {
     variables = {
-      LISTENER_ENDPOINT = "${var.forward_to}"
+      FORWARD_TO_ENDPOINT = "${var.forward_to}"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,3 +32,8 @@ variable "tf_state_backend_bucket" {
   description = "The name of the bucket where we store the terraform state file for this repository"
   default = "tf-state--group-mail-receiver"
 }
+
+variable "forward_to" {
+  description = "The endpoint for group-mailer where email references should be forwarded to, e.g. https://group-mailer.something.com/mail"
+  type = "string"
+}


### PR DESCRIPTION
The main difference is that the lambda no longer attempts to collect the S3 object or do the POST, it just takes in the object reference from the event. This simplifies the code a lot, and removes a lot of the promise logic we had.

The code is currently returning the reference in the `callback` function. Ultimately this will instead be sent as a POST to the `group-mailer` service instead. First we need to know where to send it. This is a first step.

Other changes:
- CI will update the lambda with new code when it's deployed to S3
- There's a `FORWARD_TO` environment variable, which will be the location for `group-mailer`.